### PR TITLE
Replaced tab with spaces in conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class NLJsonConan(ConanFile):
     settings = None #header only
 
     def source(self):
-	download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
+        download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
 
     def build(self):
         None #header only


### PR DESCRIPTION
You should only use tabs OR spaces, but not both, since (at least in Python 3) this will generate an error:

> TabError: inconsistent use of tabs and spaces in indentation